### PR TITLE
Apply colnames *before* coercing to a tbl_df (#739)

### DIFF
--- a/R/R/prophet.R
+++ b/R/R/prophet.R
@@ -1440,11 +1440,12 @@ predict_uncertainty <- function(m, df) {
             na.rm = TRUE)),
     t(apply(t(sim.values$trend), 2, stats::quantile, c(lower.p, upper.p),
             na.rm = TRUE))
-  ) %>% dplyr::as_data_frame()
+  )
 
   colnames(intervals) <- paste(rep(c('yhat', 'trend'), each=2),
                                c('lower', 'upper'), sep = "_")
-  return(intervals)
+
+  return(dplyr::as_data_frame(intervals))
 }
 
 #' Simulate observations from the extrapolated generative model.


### PR DESCRIPTION
`dplyr::as_data_frame()` is really `tibble::as_tibble()`. An upcoming
release of tibble will be stricter about column names and, by default,
you can't have duplicate column names. This change allows prophet to
work with current CRAN tibble (v1.4.2) and the coming release.

cc @krlmlr